### PR TITLE
allow running once for Interval <= 0; trim HTTP response whitespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,6 +160,19 @@ func UpdateDomains(configuration Config, client *ns1.Client, ipv4, ipv6 string) 
 	}
 }
 
+func runDDNS(configuration Config, client *ns1.Client) {
+	v4, v6, err := GetIPAddress(configuration.QueryAddresses)
+	if err != nil {
+		fmt.Printf("Failed to get IP address: %s\n", err.Error())
+	} else {
+		if v6 == nil {
+			UpdateDomains(configuration, client, v4.String(), "")
+		} else {
+			UpdateDomains(configuration, client, v4.String(), v6.String())
+		}
+	}
+}
+
 func main() {
 	var configuration Config
 
@@ -234,7 +247,7 @@ func main() {
 	}
 
 	// run first time
-	runddns(configuration, client)
+	runDDNS(configuration, client)
 
 	if configuration.Basic.Interval <= 0 {
 		// running once only, exiting now
@@ -244,19 +257,7 @@ func main() {
 	// else run repeatedly
 	ticker := time.NewTicker(time.Duration(configuration.Basic.Interval) * time.Second)
 	for range ticker.C {
-		runddns(configuration, client)
+		runDDNS(configuration, client)
 	}
 }
 
-func runddns(configuration Config, client *ns1.Client) {
-	v4, v6, err := GetIPAddress(configuration.QueryAddresses)
-	if err != nil {
-		fmt.Printf("Failed to get IP address: %s\n", err.Error())
-	} else {
-		if v6 == nil {
-			UpdateDomains(configuration, client, v4.String(), "")
-		} else {
-			UpdateDomains(configuration, client, v4.String(), v6.String())
-		}
-	}
-}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -56,7 +57,7 @@ func GetIPAddress(addrs QueryAddress) (ipv4, ipv6 net.IP, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	err = ipv4.UnmarshalText(v4resp)
+	err = ipv4.UnmarshalText(bytes.TrimSpace(v4resp))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -74,7 +75,7 @@ func GetIPAddress(addrs QueryAddress) (ipv4, ipv6 net.IP, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	err = ipv6.UnmarshalText(v6resp)
+	err = ipv6.UnmarshalText(bytes.TrimSpace(v6resp))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- Allow for quitting after running once if Interval is set to <= 0, e.g. for cron scripting
  - (added benefit of handling negative sleep time interval)
- Use bytes.TrimSpace() around the http response body, which fixes usage with e.g. `checkip.amazonaws.com` which emits a trailing newline